### PR TITLE
Fix Atime on Windows

### DIFF
--- a/ninep/sys_windows.go
+++ b/ninep/sys_windows.go
@@ -14,7 +14,7 @@ func GetBlockSize() (int64, error) {
 
 func Atime(info os.FileInfo) (t time.Time, ok bool) {
 
-	attr, ok := fi.Sys().(*syscall.Win32FileAttributeData)
+        attr, ok := info.Sys().(*syscall.Win32FileAttributeData)
 
 	if ok {
 		t = time.Unix(0, attr.LastAccessTime.Nanoseconds())


### PR DESCRIPTION
## Summary
- correct variable name in Windows implementation of `Atime`

## Testing
- `go vet ./ninep`
- `go build ./ninep`
