### PR TITLE
Update x/net and x/crypto versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/secure-io/sio-go v0.3.1
 	github.com/smallfz/libnfs-go v0.0.6
 	go.uber.org/automaxprocs v1.6.0
-	golang.org/x/crypto v0.32.0
+        golang.org/x/crypto v0.35.0
 	golang.org/x/image v0.22.0
 	golang.org/x/sys v0.29.0
 	periph.io/x/conn/v3 v3.7.1
@@ -75,7 +75,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.32.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.32.0 // indirect
 	go.opentelemetry.io/otel/trace v1.32.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
+        golang.org/x/net v0.38.0 // indirect
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.8.0 // indirect


### PR DESCRIPTION
## Summary
- update golang.org/x/crypto to v0.35.0
- update golang.org/x/net to v0.38.0

## Testing
- `go mod tidy` *(fails: proxyconnect tcp dial tcp 172.24.0.3:8080: connect: no route to host)*
- `go test ./...` *(fails: missing go.sum entry for module providing package golang.org/x/crypto/ssh)*