### PR TITLE
Fix various linter issues

### DIFF
--- a/fs/cachefs/handle.go
+++ b/fs/cachefs/handle.go
@@ -153,7 +153,7 @@ func (h *handle) Sync() error {
 	}
 	// we're making an educated guess that if it's read only, sync doesn't really matter much
 	if !h.isWriteable {
-		go h.h.Sync()
+		go func() { _ = h.h.Sync() }()
 		return nil
 	}
 	if h.fs.writesAsync && h.cancel != nil {
@@ -169,7 +169,7 @@ func (h *handle) Close() error {
 	}
 	// we're making an educated guess that if it's read only, close doesn't really matter much
 	if !h.isWriteable {
-		go h.h.Close()
+		go func() { _ = h.h.Close() }()
 		return nil
 	}
 	if h.fs.writesAsync && h.cancel != nil {

--- a/fs/dir.go
+++ b/fs/dir.go
@@ -108,7 +108,7 @@ func (d Dir) WriteStat(ctx context.Context, path string, s ninep.Stat) error {
 
 		defer func() {
 			if err != nil {
-				os.Rename(newPath, fullPath)
+				_ = os.Rename(newPath, fullPath)
 			}
 		}()
 
@@ -123,7 +123,7 @@ func (d Dir) WriteStat(ctx context.Context, path string, s ninep.Stat) error {
 		}
 		defer func() {
 			if err != nil {
-				os.Chmod(fullPath, old)
+				_ = os.Chmod(fullPath, old)
 			}
 		}()
 	}
@@ -182,7 +182,7 @@ func (d Dir) WriteStat(ctx context.Context, path string, s ninep.Stat) error {
 		}
 		defer func() {
 			if err != nil {
-				os.Chown(fullPath, oldUID, oldGID)
+				_ = os.Chown(fullPath, oldUID, oldGID)
 			}
 		}()
 	}
@@ -210,7 +210,7 @@ func (d Dir) WriteStat(ctx context.Context, path string, s ninep.Stat) error {
 		}
 		defer func() {
 			if err != nil {
-				os.Chtimes(fullPath, oldAtime, oldMtime)
+				_ = os.Chtimes(fullPath, oldAtime, oldMtime)
 			}
 		}()
 	}

--- a/fs/encryptfs/file.go
+++ b/fs/encryptfs/file.go
@@ -38,7 +38,7 @@ func (h *chachaFileHandle) Sync() error { return h.Backed.Sync() }
 func (h *chachaFileHandle) Close() error {
 	if h.W != nil {
 		if err := h.W.Close(); err != nil {
-			h.Backed.Close()
+			_ = h.Backed.Close()
 			return err
 		}
 	}
@@ -93,8 +93,8 @@ func openEncryptedFile(
 
 	eh, err := writeFs.OpenFile(ctx, dataPath, ninep.OREAD)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		tmpFile.Close()
-		tmpFs.Delete(ctx, tmpPath)
+		_ = tmpFile.Close()
+		_ = tmpFs.Delete(ctx, tmpPath)
 		return nil, err
 	}
 	err = nil
@@ -105,9 +105,9 @@ func openEncryptedFile(
 			var buf [4096]byte
 			_, err := io.CopyBuffer(ninep.Writer(tmpFile), h, buf[:])
 			if err != nil {
-				eh.Close()
-				tmpFile.Close()
-				tmpFs.Delete(ctx, tmpPath)
+				_ = eh.Close()
+				_ = tmpFile.Close()
+				_ = tmpFs.Delete(ctx, tmpPath)
 				return nil, err
 			}
 		}
@@ -154,15 +154,15 @@ func (h *commitHandle) commit(ctx context.Context) error {
 
 		cipher, err := PublicKeyEncrypt(h.pubKey, buf)
 		if err != nil {
-			keyFile.Close()
-			h.keyFs.Delete(ctx, h.keyPath)
+			_ = keyFile.Close()
+			_ = h.keyFs.Delete(ctx, h.keyPath)
 			return err
 		}
 
 		_, err = keyFile.WriteAt([]byte(cipher), 0)
 		if err != nil {
-			keyFile.Close()
-			h.keyFs.Delete(ctx, h.keyPath)
+			_ = keyFile.Close()
+			_ = h.keyFs.Delete(ctx, h.keyPath)
 			return err
 		}
 	}
@@ -183,7 +183,7 @@ func (h *commitHandle) commit(ctx context.Context) error {
 }
 
 func (h *commitHandle) deleteTemp() error {
-	h.tmp.Close()
+	_ = h.tmp.Close()
 	h.tmp = nil
 	return h.tmpFs.Delete(context.Background(), h.tmpPath)
 }

--- a/fs/env.go
+++ b/fs/env.go
@@ -45,7 +45,7 @@ func (d envFs) CreateFile(ctx context.Context, path string, flag ninep.OpenMode,
 		contents = os.Getenv(key)
 	}
 	onFlush := func(p []byte) error {
-		os.Setenv(key, string(p))
+		_ = os.Setenv(key, string(p))
 		return nil
 	}
 	return ninep.NewMemoryFileHandle([]byte(contents), nil, onFlush), nil
@@ -59,7 +59,7 @@ func (d envFs) OpenFile(ctx context.Context, path string, flag ninep.OpenMode) (
 		contents = os.Getenv(key)
 	}
 	onFlush := func(p []byte) error {
-		os.Setenv(key, string(p))
+		_ = os.Setenv(key, string(p))
 		return nil
 	}
 	return ninep.NewMemoryFileHandle([]byte(contents), nil, onFlush), nil
@@ -110,9 +110,9 @@ func (d envFs) WriteStat(ctx context.Context, path string, s ninep.Stat) error {
 	}
 
 	if !s.NameNoTouch() && path != s.Name() {
-		os.Unsetenv(key)
+		_ = os.Unsetenv(key)
 		newKey := d.key(s.Name())
-		os.Setenv(newKey, value)
+		_ = os.Setenv(newKey, value)
 		key = newKey
 	}
 
@@ -121,7 +121,7 @@ func (d envFs) WriteStat(ctx context.Context, path string, s ninep.Stat) error {
 		if s.Length() < uint64(len(value)) {
 			value = value[:s.Length()]
 		}
-		os.Setenv(key, value)
+		_ = os.Setenv(key, value)
 	}
 	return nil
 }
@@ -134,7 +134,7 @@ func (d envFs) Delete(ctx context.Context, path string) error {
 	key := d.key(path)
 	_, found := os.LookupEnv(key)
 	if found {
-		os.Unsetenv(key)
+		_ = os.Unsetenv(key)
 		return nil
 	}
 	return fs.ErrNotExist

--- a/fs/procfs/sys_linux.go
+++ b/fs/procfs/sys_linux.go
@@ -93,7 +93,9 @@ func pidFds(p Pid) ([]Fd, error) {
 				return nil, err
 			}
 			buf, err := io.ReadAll(f)
-			f.Close()
+			if cerr := f.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -169,7 +171,9 @@ func pidEnv(p Pid) ([]string, error) {
 		return nil, err
 	}
 	buf, err := io.ReadAll(f)
-	f.Close()
+	if cerr := f.Close(); cerr != nil && err == nil {
+		err = cerr
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +204,9 @@ func pidArgs(p Pid) ([]string, error) {
 		return nil, err
 	}
 	buf, err := io.ReadAll(f)
-	f.Close()
+	if cerr := f.Close(); cerr != nil && err == nil {
+		err = cerr
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +239,9 @@ func pidInfo(p Pid) (ProcInfo, error) {
 		return pi, err
 	}
 	buf, err := io.ReadAll(f)
-	f.Close()
+	if cerr := f.Close(); cerr != nil && err == nil {
+		err = cerr
+	}
 	if err != nil {
 		return pi, err
 	}

--- a/fs/proxy/mounts.go
+++ b/fs/proxy/mounts.go
@@ -32,7 +32,7 @@ func (fsm *FileSystemMount) Close() error {
 	if fsm.Clean != nil {
 		err := fsm.Clean()
 		if err != nil {
-			fsm.Client.Close()
+			_ = fsm.Client.Close()
 			return err
 		}
 	}
@@ -73,11 +73,11 @@ func ParseMounts(args []string) []FileSystemMountConfig {
 }
 
 func PrintMountsHelp(w io.Writer) {
-	fmt.Fprintf(w, "\nMounts refers to a 9p server and path and are represented like <SERVER>:<PORT><PATH> like 'localhost:6666/prefix/path'.\n")
-	fmt.Fprintf(w, "\nThere are a few special mount values that are recognized:\n")
-	fmt.Fprintf(w, "  - ':memory' indicates an in memory file system that gets discarded after the program exits.\n")
-	fmt.Fprintf(w, "  - ':tmp' indicates an on-disk temporarily directory that gets discarded after the program exits.\n")
-	fmt.Fprintf(w, "  -  starting with a '/' or '.' indicates an on-disk local path.\n")
+	_, _ = fmt.Fprintf(w, "\nMounts refers to a 9p server and path and are represented like <SERVER>:<PORT><PATH> like 'localhost:6666/prefix/path'.\n")
+	_, _ = fmt.Fprintf(w, "\nThere are a few special mount values that are recognized:\n")
+	_, _ = fmt.Fprintf(w, "  - ':memory' indicates an in memory file system that gets discarded after the program exits.\n")
+	_, _ = fmt.Fprintf(w, "  - ':tmp' indicates an on-disk temporarily directory that gets discarded after the program exits.\n")
+	_, _ = fmt.Fprintf(w, "  -  starting with a '/' or '.' indicates an on-disk local path.\n")
 }
 
 func (fsm *FileSystemMount) Join(elem ...string) string {

--- a/fs/sftpfs/fs.go
+++ b/fs/sftpfs/fs.go
@@ -136,7 +136,7 @@ func (fs *sftpFs) WriteStat(ctx context.Context, path string, s ninep.Stat) erro
 
 		defer func() {
 			if err != nil {
-				fs.conn.Rename(newPath, fullPath)
+				_ = fs.conn.Rename(newPath, fullPath)
 			}
 		}()
 
@@ -151,7 +151,7 @@ func (fs *sftpFs) WriteStat(ctx context.Context, path string, s ninep.Stat) erro
 		}
 		defer func() {
 			if err != nil {
-				fs.conn.Chmod(fullPath, old)
+				_ = fs.conn.Chmod(fullPath, old)
 			}
 		}()
 	}
@@ -180,7 +180,7 @@ func (fs *sftpFs) WriteStat(ctx context.Context, path string, s ninep.Stat) erro
 		}
 		defer func() {
 			if err != nil {
-				fs.conn.Chtimes(fullPath, oldAtime, oldMtime)
+				_ = fs.conn.Chtimes(fullPath, oldAtime, oldMtime)
 			}
 		}()
 	}

--- a/ninep/client.go
+++ b/ninep/client.go
@@ -51,7 +51,7 @@ func (t *cltTransaction) clone() *cltTransaction {
 }
 
 func (t *cltTransaction) sendAndReceive(rw net.Conn) (Message, error) {
-	rw.SetDeadline(time.Time{})
+	_ = rw.SetDeadline(time.Time{})
 	err := t.req.writeRequest(rw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write %s: %w", t.req.requestType(), err)
@@ -188,7 +188,7 @@ func (f *FileProxy) WriteStat(st Stat) error {
 func (f *FileProxy) CreateDir(name string, mode Mode) (*FileProxy, error) {
 	fp, err := f.CreateFile(name, ORDWR, mode|M_DIR)
 	if err == nil {
-		fp.Close()
+		_ = fp.Close()
 	}
 	return fp, err
 }
@@ -213,7 +213,7 @@ func (f *FileProxy) CreateFile(name string, flag OpenMode, mode Mode) (*FileProx
 	if err == nil {
 		h = &FileProxy{fs, fid, qids[len(qids)-1], nil}
 	} else {
-		fs.c.Clunk(fid)
+		_ = fs.c.Clunk(fid)
 		fs.releaseFid(fid)
 	}
 	return h, err
@@ -408,7 +408,7 @@ func (fs *FileSystemProxy) walk(fid Fid, path string) (Qid, error) {
 	qids, err := fs.c.Walk(fs.rootF, fid, parts)
 	if err != nil {
 		// Best attempt to notify server that we're dropping this fid
-		fs.c.Clunk(fid)
+		_ = fs.c.Clunk(fid)
 		return nil, err
 	}
 	if len(qids) < len(parts) {
@@ -436,7 +436,7 @@ func (fs *FileSystemProxy) MakeDir(ctx context.Context, path string, mode Mode) 
 		return err
 	}
 	_, _, err := fs.c.Create(fid, filename, mode|M_DIR, ORDWR)
-	fs.c.Clunk(fid)
+	_ = fs.c.Clunk(fid)
 	fs.releaseFid(fid)
 	return err
 }
@@ -459,7 +459,7 @@ func (fs *FileSystemProxy) CreateFile(ctx context.Context, path string, flag Ope
 	if err == nil {
 		h = &FileProxy{fs, fid, qid, nil}
 	} else {
-		fs.c.Clunk(fid)
+		_ = fs.c.Clunk(fid)
 		fs.releaseFid(fid)
 	}
 	return h, err
@@ -474,14 +474,14 @@ func (fs *FileSystemProxy) OpenFile(ctx context.Context, path string, flag OpenM
 	qid, _, err := fs.c.Open(fid, flag)
 	if err == nil {
 		if qid.Type().IsDir() {
-			fs.c.Clunk(fid)
+			_ = fs.c.Clunk(fid)
 			fs.releaseFid(fid)
 			err = ErrOpenDirNotAllowed
 		} else {
 			h = &FileProxy{fs, fid, qid, nil}
 		}
 	} else {
-		fs.c.Clunk(fid)
+		_ = fs.c.Clunk(fid)
 		fs.releaseFid(fid)
 	}
 	return h, err
@@ -527,7 +527,7 @@ func (fs *FileSystemProxy) Stat(ctx context.Context, path string) (os.FileInfo, 
 		return nil, err
 	}
 	st, err := fs.c.Stat(fid)
-	fs.c.Clunk(fid)
+	_ = fs.c.Clunk(fid)
 	return st.FileInfo(), err
 }
 func (fs *FileSystemProxy) WriteStat(ctx context.Context, path string, s Stat) error {
@@ -537,7 +537,7 @@ func (fs *FileSystemProxy) WriteStat(ctx context.Context, path string, s Stat) e
 		return err
 	}
 	err := fs.c.WriteStat(fid, s)
-	fs.c.Clunk(fid)
+	_ = fs.c.Clunk(fid)
 	return err
 }
 func (fs *FileSystemProxy) Delete(ctx context.Context, path string) error {
@@ -729,7 +729,7 @@ func (t *BasicTraversableFile) Create(name string, flag OpenMode, mode Mode) (Tr
 
 	info, err := t.FS.Stat(ctx, fpath)
 	if err != nil {
-		h.Close()
+		_ = h.Close()
 		return nil, err
 	}
 
@@ -757,7 +757,7 @@ func (t *BasicTraversableFile) Open(flag OpenMode) error {
 	if t.Info == nil {
 		info, err = t.FS.Stat(ctx, t.Path)
 		if err != nil {
-			h.Close()
+			_ = h.Close()
 			return err
 		}
 		t.Info = info

--- a/ninep/client_transport.go
+++ b/ninep/client_transport.go
@@ -58,7 +58,7 @@ func (t *SerialClientTransport) Connect(d Dialer, network, addr, usr, mnt string
 	txn := createClientTransaction(NO_TAG, DEFAULT_MAX_MESSAGE_SIZE)
 	msgSize, err := acceptRversion(L, t.rwc, &txn, DEFAULT_MAX_MESSAGE_SIZE, 0)
 	if err != nil {
-		t.rwc.Close()
+		_ = t.rwc.Close()
 		return err
 	}
 
@@ -119,7 +119,7 @@ func (t *ParallelClientTransport) Connect(d Dialer, network, addr, usr, mnt stri
 	txn := createClientTransaction(NO_TAG, DEFAULT_MAX_MESSAGE_SIZE)
 	msgSize, err := acceptRversion(L, t.rwc, &txn, DEFAULT_MAX_MESSAGE_SIZE, 0)
 	if err != nil {
-		t.rwc.Close()
+		_ = t.rwc.Close()
 		return err
 	}
 
@@ -328,7 +328,7 @@ func (t *SerialRetryClientTransport) unsafeConnect() error {
 	txn := createClientTransaction(NO_TAG, DEFAULT_MAX_MESSAGE_SIZE)
 	msgSize, err := acceptRversion(t.Logger, t.rwc, &txn, DEFAULT_MAX_MESSAGE_SIZE, 0)
 	if err != nil {
-		t.rwc.Close()
+		_ = t.rwc.Close()
 		return err
 	}
 

--- a/ninep/fs.go
+++ b/ninep/fs.go
@@ -680,10 +680,10 @@ func (h *RWFileHandle) WriteAt(p []byte, off int64) (n int, err error) {
 func (h *RWFileHandle) Sync() error { return nil }
 func (h *RWFileHandle) Close() error {
 	if rc, ok := h.R.(io.Closer); ok {
-		rc.Close()
+		_ = rc.Close()
 	}
 	if wc, ok := h.W.(io.Closer); ok {
-		wc.Close()
+		_ = wc.Close()
 	}
 	return nil
 }

--- a/ninep/messages.go
+++ b/ninep/messages.go
@@ -944,7 +944,7 @@ var _ os.FileInfo = (*statFileInfo)(nil)
 func (s statFileInfo) Size() int64        { return int64(s.Stat.Length()) }
 func (s statFileInfo) Name() string       { return s.Stat.Name() }
 func (s statFileInfo) Mode() fs.FileMode  { return s.Stat.Mode().ToFsMode() }
-func (s statFileInfo) ModTime() time.Time { return time.Unix(int64(s.Stat.Mtime()), 0) }
+func (s statFileInfo) ModTime() time.Time { return time.Unix(int64(s.Mtime()), 0) }
 func (s statFileInfo) IsDir() bool        { return s.Stat.Mode()&M_DIR != 0 }
 func (s statFileInfo) Sys() interface{}   { return s.Stat }
 
@@ -1546,12 +1546,12 @@ func PathSplit(path string) []string {
 	if len(path) > 0 && path[0] != '/' {
 		path = "/" + path
 	}
-	if path == "" {
+	switch path {
+	case "", "/":
 		return []string{""}
-	} else if path == "/" {
-		return []string{""}
+	default:
+		return strings.Split(path, "/")
 	}
-	return strings.Split(path, "/")
 }
 
 func IsSubpath(path, parentPath string) bool {

--- a/ninep/ndb/ndb.go
+++ b/ninep/ndb/ndb.go
@@ -255,7 +255,6 @@ func (n *Ndb) byPredicate(allow func(rec []byte) bool) iter.Seq[Record] {
 								continue
 							}
 							if !yield(results) {
-								recBytes = recBytes[:0]
 								break loop
 							}
 						}
@@ -278,7 +277,6 @@ func (n *Ndb) byPredicate(allow func(rec []byte) bool) iter.Seq[Record] {
 					err := parseRecord(recBytes, &results)
 					if err == nil {
 						if !yield(results) {
-							recBytes = recBytes[:0]
 							break
 						}
 					} else {
@@ -358,7 +356,6 @@ func parseRecord(recBytes []byte, results *Record) error {
 	for len(r) > 0 {
 		ch, size := utf8.DecodeRune(r)
 		if ch == utf8.RuneError {
-			r = r[size:]
 			return fmt.Errorf("invalid utf8 rune")
 		}
 		if unicode.IsSpace(ch) {

--- a/ninep/ndb/ndb_test.go
+++ b/ninep/ndb/ndb_test.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 	"testing"
 
-	"github.com/jeffh/cfs/fs"
 	nfs "github.com/jeffh/cfs/fs"
 	"github.com/jeffh/cfs/ninep"
 )
@@ -13,7 +12,7 @@ import (
 var exampleFiles embed.FS
 
 func TestReadingFromEmbedFS(t *testing.T) {
-	m := fs.ReadOnlyFS(exampleFiles)
+	m := nfs.ReadOnlyFS(exampleFiles)
 	t.Run("Open properly opens recursively", func(t *testing.T) {
 		db := mustOpen(t, m, "example/start.ndb")
 		records := db.SearchSlice(HasAttrValue("givenName", "John"))


### PR DESCRIPTION
## Summary
- address errcheck warnings by handling returned errors
- fix staticcheck suggestions in messages and ndb tests
- clean up unused imports and update helper functions

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: Error return value of `os.Stdin.Close` is not checked, etc.)*
