### PR TITLE
Fix lint errors

### DIFF
--- a/cli/client_main.go
+++ b/cli/client_main.go
@@ -64,11 +64,11 @@ func (c *ClientConfig) FSMount(mnt *proxy.FileSystemMountConfig) (proxy.FileSyst
 	case ":tmp":
 		dir, err := os.MkdirTemp("", "*")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to create temp directory: %s", err)
+			_, _ = fmt.Fprintf(os.Stderr, "Failed to create temp directory: %s", err)
 		}
 		clean := func() error {
 			if err := os.RemoveAll(dir); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to clean temp directory: %s: %s", dir, err)
+				_, _ = fmt.Fprintf(os.Stderr, "Failed to clean temp directory: %s: %s", dir, err)
 				return err
 			}
 			return nil
@@ -104,7 +104,7 @@ func (c *ClientConfig) FSMountMany(cfgs []proxy.FileSystemMountConfig) ([]proxy.
 		m, err := c.FSMount(&cfg)
 		if err != nil {
 			for _, m := range mnts {
-				m.Close()
+				_ = m.Close()
 			}
 			return nil, err
 		}
@@ -153,7 +153,7 @@ func (c *ClientConfig) CreateFs(addr string) (ninep.Client, *ninep.FileSystemPro
 	}
 	fs, err := client.Fs()
 	if err != nil {
-		client.Close()
+		_ = client.Close()
 		return nil, nil, fmt.Errorf("failed to attach to 9p server: %w", err)
 	}
 	return client, fs, nil
@@ -192,23 +192,23 @@ func MainClient(fn func(cfg *ClientConfig, m proxy.FileSystemMount) error) {
 
 	mntCfg, ok := proxy.ParseMount(args[0])
 	if !ok {
-		fmt.Fprintf(os.Stderr, "Invalid path: %v\n", args[0])
-		fmt.Fprintf(os.Stderr, "Format should be IP:PORT/PATH format.\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Invalid path: %v\n", args[0])
+		_, _ = fmt.Fprintf(os.Stderr, "Format should be IP:PORT/PATH format.\n")
 		exitCode = 1
 		runtime.Goexit()
 	}
 
 	mnt, err := cfg.FSMount(&mntCfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error connecting to destination fs: %s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error connecting to destination fs: %s\n", err)
 		exitCode = 1
 		runtime.Goexit()
 	}
-	defer mnt.Close()
+	defer func() { _ = mnt.Close() }()
 
 	err = fn(&cfg, mnt)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
 		exitCode = 1
 		runtime.Goexit()
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -40,7 +40,7 @@ func (f *StdFlags) ReadFileConfig(filename string) error {
 	if err != nil {
 		return err
 	}
-	defer h.Close()
+	defer func() { _ = h.Close() }()
 
 	b, err := io.ReadAll(h)
 	if err != nil {

--- a/cmd/cachefs/main.go
+++ b/cmd/cachefs/main.go
@@ -40,9 +40,9 @@ func main() {
 	flag.BoolVar(&asyncWrites, "async-writes", false, "Asynchronously writes to source")
 	flag.Usage = func() {
 		w := flag.CommandLine.Output()
-		fmt.Fprintf(w, "Usage: %s [OPTIONS]\n\n", os.Args[0])
-		fmt.Fprintf(w, "Caches a 9p file system for faster access.\n\n")
-		fmt.Fprintf(w, "OPTIONS:\n")
+		_, _ = fmt.Fprintf(w, "Usage: %s [OPTIONS]\n\n", os.Args[0])
+		_, _ = fmt.Fprintf(w, "Caches a 9p file system for faster access.\n\n")
+		_, _ = fmt.Fprintf(w, "OPTIONS:\n")
 		flag.PrintDefaults()
 	}
 
@@ -51,17 +51,17 @@ func main() {
 	cltCfg.Logger = srvCfg.Logger
 
 	if fromAddr == "" {
-		fmt.Fprintf(os.Stderr, "Error: -fromfs is required\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Error: -fromfs is required\n")
 		flag.Usage()
 		os.Exit(1)
 	}
 	client, fsy, err := cltCfg.CreateFs(fromAddr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error connecting to source fs: %s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error connecting to source fs: %s\n", err)
 		os.Exit(1)
 	}
 
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	createcfg := func(stdout, stderr io.Writer) cli.ServerConfig {
 		srvCfg.Stdout = stdout

--- a/cmd/cpipe/main.go
+++ b/cmd/cpipe/main.go
@@ -25,9 +25,9 @@ func main() {
 
 	flag.Usage = func() {
 		w := flag.CommandLine.Output()
-		fmt.Fprintf(w, "Usage: %s [OPTIONS] ADDR/PATH\n\n", os.Args[0])
-		fmt.Fprintf(w, "Shell Pipe for CFS. Writes STDIN into a file.\n\n")
-		fmt.Fprintf(w, "OPTIONS:\n")
+		_, _ = fmt.Fprintf(w, "Usage: %s [OPTIONS] ADDR/PATH\n\n", os.Args[0])
+		_, _ = fmt.Fprintf(w, "Shell Pipe for CFS. Writes STDIN into a file.\n\n")
+		_, _ = fmt.Fprintf(w, "OPTIONS:\n")
 		flag.PrintDefaults()
 	}
 
@@ -57,7 +57,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		defer h.Close()
+		defer func() { _ = h.Close() }()
 
 		wtr := ninep.Writer(h)
 		if append {


### PR DESCRIPTION
## Summary
- handle fmt errors and close return values
- tweak loops and add error checks in `ccat`
- silence lints in client and server helpers
- silence lint warnings in pipeline and cachefs commands

## Testing
- `golangci-lint run cmd/ccat/main.go`
- `golangci-lint run cmd/cpipe/main.go`
- `golangci-lint run cmd/cachefs/main.go`
- `golangci-lint run ./cli`
- `golangci-lint run | head -n 20`
- `go test ./... | head -n 20`
