### PR TITLE
Fix initial 30 golangci-lint issues

### DIFF
--- a/exportfs/fuse/fs.go
+++ b/exportfs/fuse/fs.go
@@ -355,7 +355,11 @@ func (n *Dir) Create(ctx context.Context, name string, flags uint32, mode uint32
 
 		info, err := n.fs.Stat(ctx, path)
 		if err != nil {
-			h.Close()
+			if cerr := h.Close(); cerr != nil {
+				if n.config.L != nil {
+					n.config.L.WarnContext(ctx, "close handle", slog.String("err", cerr.Error()))
+				}
+			}
 			return nil, nil, 0, mapErr(err, syscall.EINVAL) // TODO: what's better to report here?
 		}
 
@@ -366,7 +370,11 @@ func (n *Dir) Create(ctx context.Context, name string, flags uint32, mode uint32
 		}
 
 		if errno := fillAttr(n.config, info, &out.Attr); errno != 0 {
-			h.Close()
+			if cerr := h.Close(); cerr != nil {
+				if n.config.L != nil {
+					n.config.L.WarnContext(ctx, "close handle", slog.String("err", cerr.Error()))
+				}
+			}
 			return nil, nil, 0, errno
 		}
 		if n.config.L != nil {

--- a/fs/einkfs/alt.go
+++ b/fs/einkfs/alt.go
@@ -85,7 +85,9 @@ func (f *internalState) unsafeBlit(img image.Image) {
 	zero := image.Point{}
 	draw.Draw(f.display, f.display.Bounds(), img, zero, draw.Src)
 	if time.Since(f.lastUpdated) >= 24*time.Hour {
-		f.dev.Clear(image.White)
+		if err := f.dev.Clear(image.White); err != nil {
+			log.Printf("clear display: %v", err)
+		}
 		f.lastUpdated = time.Now()
 	}
 	err := f.dev.Draw(f.dev.Bounds(), f.display, zero)


### PR DESCRIPTION
## Summary
- address unchecked errors in cexe
- handle handle closure errors in fuse exportfs
- check eink display clearing errors
- tweak usage writing in cexe

## Testing
- `golangci-lint run`
- `make test`
